### PR TITLE
Rename test file and fix filterable tags generator test.  Refactor to use OrderedDict in `Filter` class.

### DIFF
--- a/picard/ui/filter.py
+++ b/picard/ui/filter.py
@@ -19,6 +19,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import OrderedDict
+
 from PyQt6 import (
     QtCore,
     QtWidgets,
@@ -61,10 +63,10 @@ class Filter(QtWidgets.QWidget):
         self.filter_query_box.textChanged.connect(self._query_changed)
         layout.addWidget(self.filter_query_box)
 
-    file_filters = {
+    file_filters = OrderedDict({
         'filename': N_("Filename"),
         'filepath': N_("Filepath"),
-    }
+    })
 
     def _show_filter_dialog(self):
         """Show dialog to select multiple filters"""
@@ -90,8 +92,8 @@ class Filter(QtWidgets.QWidget):
         scroll_layout.addWidget(line)
 
         checkboxes = {}
-        for file_filter in ["filename", "filepath"]:
-            checkbox = QtWidgets.QCheckBox(_(self.file_filters[file_filter]), scroll_content)
+        for file_filter, title in self.file_filters.items():
+            checkbox = QtWidgets.QCheckBox(_(title), scroll_content)
             checkbox.setChecked(file_filter in self.selected_filters)
             scroll_layout.addWidget(checkbox)
             checkboxes[file_filter] = checkbox

--- a/test/test_ui_filter.py
+++ b/test/test_ui_filter.py
@@ -38,10 +38,12 @@ TEST_TAGS = TagVars(
     TagVar(
         'album',
         shortdesc='Album',
+        is_filterable=True,
     ),
     TagVar(
         'artist',
         shortdesc='Artist',
+        is_filterable=True,
     ),
     TagVar(
         'bitrate',
@@ -70,6 +72,7 @@ TEST_TAGS = TagVars(
     TagVar(
         'title',
         shortdesc='Title',
+        is_filterable=True,
     ),
 )
 
@@ -101,11 +104,11 @@ class FilterxTest(PicardTestCase):
             self.assertEqual(button_text, expected_text,
                            f"Filter list {selected_filters} should produce '{expected_text}'")
 
-    @patch('picard.ui.filter.ALL_TAGS', TEST_TAGS)
+    @patch('picard.tags.ALL_TAGS', TEST_TAGS)
     def test_filterable_tags(self):
         """Test generation of valid tags"""
         filterable_tags = set(str(x) for x in Filter.get_filterable_tags())
-        self.assertEqual(len(filterable_tags), 35)
+        self.assertEqual(len(filterable_tags), 3)
 
         tag_names = ['album', 'artist', 'title']
         for name in tag_names:


### PR DESCRIPTION
Rename the `test_ui_find.py` file to `test_ui_filter.py` to match other file and class name changes.

Fix the filterable tags generator test to use the mocked `ALL_TAGS` constant.

Refactor the `Filter` class to use an OrderedDict to avoid having to manually sort the `filename` and `filepath` filter checkboxes.