### PR TITLE
Make filter bar display a persistent setting to restore on startup

### DIFF
--- a/picard/options.py
+++ b/picard/options.py
@@ -139,6 +139,7 @@ BoolOption('persist', 'view_cover_art', True)
 BoolOption('persist', 'view_file_browser', False)
 BoolOption('persist', 'view_metadata_view', True)
 BoolOption('persist', 'view_toolbar', True)
+BoolOption('persist', 'view_filterbar', False)
 BoolOption('persist', 'window_maximized', False)
 Option('persist', 'window_state', QtCore.QByteArray())
 

--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -22,7 +22,7 @@
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2020-2021 Gabriel Ferreira
-# Copyright (C) 2021 Bob Swift
+# Copyright (C) 2021, 2025 Bob Swift
 # Copyright (C) 2021 Louis Sautier
 # Copyright (C) 2021 Petit Minion
 # Copyright (C) 2023 certuna
@@ -249,12 +249,11 @@ class MainPanel(QtWidgets.QSplitter):
                 self._update_selection(view)
                 break
 
-    def toggle_filter_boxes(self):
-        """Toggle visibility of filter boxes in both views."""
-        visible = not self._views[0].filter_box.isVisible()
+    def show_filter_bars(self, show_state: bool):
+        """Toggle visibility of filter bars in both views."""
         for view in self._views:
-            view.filter_box.setVisible(visible)
-            if visible and view.hasFocus():
+            view.filter_box.setVisible(show_state)
+            if show_state and view.hasFocus():
                 view.filter_box.set_focus()
             else:
                 view.filter_box.clear()

--- a/picard/ui/mainwindow/__init__.py
+++ b/picard/ui/mainwindow/__init__.py
@@ -25,7 +25,7 @@
 # Copyright (C) 2018 Kartik Ohri
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018 virusMac
-# Copyright (C) 2018, 2021-2023 Bob Swift
+# Copyright (C) 2018, 2021-2023, 2025 Bob Swift
 # Copyright (C) 2019 Timur Enikeev
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021 Petit Minion
@@ -242,6 +242,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
 
         self.show_metadata_view()
         self.show_cover_art()
+        self.show_filter_bars()
 
         main_layout.addWidget(self.panel)
         main_layout.addWidget(self.metadata_view)
@@ -367,6 +368,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         config.persist['view_metadata_view'] = self.action_is_checked(MainAction.SHOW_METADATA_VIEW)
         config.persist['view_cover_art'] = self.action_is_checked(MainAction.SHOW_COVER_ART)
         config.persist['view_toolbar'] = self.action_is_checked(MainAction.SHOW_TOOLBAR)
+        config.persist['view_filterbar'] = self.action_is_checked(MainAction.SHOW_FILTERBAR)
         config.persist['view_file_browser'] = self.action_is_checked(MainAction.SHOW_FILE_BROWSER)
         self.file_browser.save_state()
         self.panel.save_state()
@@ -1633,9 +1635,9 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
     def show_plugins_options_page(self):
         self.show_options(page='plugins')
 
-    def toggle_filter_boxes(self):
-        """Toggle the filter boxes in the main panel."""
-        self.panel.toggle_filter_boxes()
+    def show_filter_bars(self):
+        show_state = self.action_is_checked(MainAction.SHOW_FILTERBAR)
+        self.panel.show_filter_bars(show_state)
 
 
 def update_last_check_date(is_success):

--- a/picard/ui/mainwindow/actions.py
+++ b/picard/ui/mainwindow/actions.py
@@ -25,7 +25,7 @@
 # Copyright (C) 2018 Kartik Ohri
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2018 virusMac
-# Copyright (C) 2018, 2021-2023 Bob Swift
+# Copyright (C) 2018, 2021-2023, 2025 Bob Swift
 # Copyright (C) 2019 Timur Enikeev
 # Copyright (C) 2020-2021 Gabriel Ferreira
 # Copyright (C) 2021 Petit Minion
@@ -349,11 +349,14 @@ def _create_show_toolbar_action(parent):
 
 @add_action(MainAction.SHOW_FILTERBAR)
 def _create_filter_bar_action(parent):
+    config = get_config()
     action = QtGui.QAction(_("Filter Items"), parent)
     action.setStatusTip(_("Toggle filtering of items based on specific tag values."))
     action.setCheckable(True)
     action.setShortcut(QtGui.QKeySequence(_("Ctrl+Shift+F")))
-    action.triggered.connect(parent.toggle_filter_boxes)
+    if config.persist['view_filterbar']:
+        action.setChecked(True)
+    action.triggered.connect(parent.show_filter_bars)
     return action
 
 

--- a/test/test_ui_filter.py
+++ b/test/test_ui_filter.py
@@ -135,4 +135,4 @@ class MainPanelFilterTest(PicardTestCase):
 
     def test_main_panel_has_toggle_method(self):
         """Test that MainPanel has the toggle_filter_boxes method"""
-        self.assertTrue(hasattr(MainPanel, 'toggle_filter_boxes'))
+        self.assertTrue(hasattr(MainPanel, 'show_filter_bars'))

--- a/test/test_ui_filter.py
+++ b/test/test_ui_filter.py
@@ -134,5 +134,5 @@ class MainPanelFilterTest(PicardTestCase):
     """Test filter functionality integration in MainPanel"""
 
     def test_main_panel_has_toggle_method(self):
-        """Test that MainPanel has the toggle_filter_boxes method"""
+        """Test that MainPanel has the show_filter_bars method"""
         self.assertTrue(hasattr(MainPanel, 'show_filter_bars'))


### PR DESCRIPTION
This adds a persistent setting to automatically restore the filter bar visibility state on start-up.  This is something that was requested by the reviewers.