### PR TITLE
Exclude unmatched files and cluster entries from filtering

### DIFF
--- a/picard/ui/itemviews/__init__.py
+++ b/picard/ui/itemviews/__init__.py
@@ -269,10 +269,12 @@ class FileTreeView(BaseTreeView):
 
     def __init__(self, columns, window, parent=None):
         super().__init__(columns, window, parent=parent)
-        self.unmatched_files = ClusterItem(self.tagger.unclustered_files, parent=self)
+        self.unmatched_files = ClusterItem(
+            self.tagger.unclustered_files, filterable=False, parent=self)
         self.unmatched_files.update()
         self.unmatched_files.setExpanded(True)
-        self.clusters = ClusterItem(self.tagger.clusters, parent=self)
+        self.clusters = ClusterItem(
+            self.tagger.clusters, filterable=False, parent=self)
         self.set_clusters_text()
         self.clusters.setExpanded(True)
         self.tagger.cluster_added.connect(self.add_file_cluster)
@@ -330,11 +332,12 @@ class AlbumTreeView(BaseTreeView):
 class TreeItem(QtWidgets.QTreeWidgetItem):
     columns = ITEMVIEW_COLUMNS
 
-    def __init__(self, obj, sortable=False, parent=None):
+    def __init__(self, obj, sortable=False, filterable=True, parent=None):
         super().__init__(parent)
         self._obj = None
         self.obj = obj
         self.sortable = sortable
+        self.filterable = filterable
         self._sortkeys = {}
         self.post_init()
 

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -631,7 +631,8 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                 child_match |= child_matches
 
             # Hide/show based on match
-            child.setHidden(not child_match)
+            if child.filterable:
+                child.setHidden(not child_match)
             match_found |= child_match
 
         return match_found


### PR DESCRIPTION
As discussed in #2668 this excludes the "Unmatched" files and "Clusters" special items from filtering. It does not generally keep "Clusters" with `special=True`, as there are others that are fine to hide (NAT and unmatched files on an album).

But I'm not 100% sure if it is actually better. On the one hand I think it is good to keep those entries, as they are otherwise also always visible and not removable. But filtering would still also show the counts, which might be confusing especially with empty result?

![image](https://github.com/user-attachments/assets/5facc407-af4e-4e99-aeba-b100c0174155)

