### PR TITLE
Use `filterable_tag_names()` to provide all filter items

### DIFF
--- a/picard/tags/__init__.py
+++ b/picard/tags/__init__.py
@@ -97,7 +97,7 @@ def hidden_tag_names():
 
 
 def filterable_tag_names():
-    yield from ALL_TAGS.names(selector=lambda tv: tv.is_tag and tv.is_filterable)
+    yield from ALL_TAGS.names(selector=lambda tv: tv.is_filterable)
 
 
 def preserved_tag_names():

--- a/picard/ui/filter.py
+++ b/picard/ui/filter.py
@@ -19,8 +19,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from collections import OrderedDict
-
 from PyQt6 import (
     QtCore,
     QtWidgets,
@@ -63,11 +61,6 @@ class Filter(QtWidgets.QWidget):
         self.filter_query_box.textChanged.connect(self._query_changed)
         layout.addWidget(self.filter_query_box)
 
-    file_filters = OrderedDict({
-        'filename': N_("Filename"),
-        'filepath': N_("Filepath"),
-    })
-
     def _show_filter_dialog(self):
         """Show dialog to select multiple filters"""
         dialog = QtWidgets.QDialog(self)
@@ -82,35 +75,10 @@ class Filter(QtWidgets.QWidget):
         scroll_content = QtWidgets.QWidget(scroll)
         scroll_layout = QtWidgets.QVBoxLayout(scroll_content)
 
-        label = QtWidgets.QLabel(_("File Filters"), scroll_content)
-        scroll_layout.addWidget(label)
-
-        # Add a horizontal separator
-        line = QtWidgets.QFrame(scroll_content)
-        line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
-        scroll_layout.addWidget(line)
-
         checkboxes = {}
-        for file_filter, title in self.file_filters.items():
-            checkbox = QtWidgets.QCheckBox(_(title), scroll_content)
-            checkbox.setChecked(file_filter in self.selected_filters)
-            scroll_layout.addWidget(checkbox)
-            checkboxes[file_filter] = checkbox
-
-        scroll_layout.addItem(QtWidgets.QSpacerItem(0, 10, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Fixed))
-
-        label = QtWidgets.QLabel(_("Tag Filters"), scroll_content)
-        scroll_layout.addWidget(label)
-
-        # Add a horizontal separator
-        line = QtWidgets.QFrame(scroll_content)
-        line.setFrameShape(QtWidgets.QFrame.Shape.HLine)
-        line.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
-        scroll_layout.addWidget(line)
 
         # Add checkboxes for all tags
-        for tag in sorted(self.filterable_tags, key=lambda t: ALL_TAGS.display_name(str(t)).lower()):
+        for tag in sorted(self.filterable_tags, key=lambda t: ALL_TAGS.display_name(t).lower()):
             checkbox = QtWidgets.QCheckBox(ALL_TAGS.display_name(str(tag)), scroll_content)
             checkbox.setChecked(str(tag) in self.selected_filters)
             scroll_layout.addWidget(checkbox)
@@ -152,10 +120,7 @@ class Filter(QtWidgets.QWidget):
             return None
 
         if len(selected_filters) == 1:
-            if selected_filters[0] not in cls.file_filters.keys():
-                return ALL_TAGS.display_name(selected_filters[0])
-            else:
-                return _(cls.file_filters[selected_filters[0]])
+            return _(ALL_TAGS.display_name(selected_filters[0]))
 
         return _("{num} filters").format(num=len(selected_filters))
 

--- a/picard/ui/filter.py
+++ b/picard/ui/filter.py
@@ -81,6 +81,7 @@ class Filter(QtWidgets.QWidget):
         for tag in sorted(self.filterable_tags, key=lambda t: ALL_TAGS.display_name(t).lower()):
             checkbox = QtWidgets.QCheckBox(ALL_TAGS.display_name(str(tag)), scroll_content)
             checkbox.setChecked(str(tag) in self.selected_filters)
+            checkbox.setToolTip(ALL_TAGS.display_tooltip(tag))
             scroll_layout.addWidget(checkbox)
             checkboxes[str(tag)] = checkbox
 

--- a/picard/ui/itemviews/basetreeview.py
+++ b/picard/ui/itemviews/basetreeview.py
@@ -599,15 +599,15 @@ class BaseTreeView(QtWidgets.QTreeWidget):
                 obj = child.obj
 
                 # Handle Clusters
-                if filters == [] or any(f in filters for f in ("filename", "filepath")):
+                if filters == [] or any(f in filters for f in ("~filename", "~filepath")):
                     # Handle Tracks with files
                     if hasattr(obj, 'iterfiles'):
                         for file_ in obj.iterfiles():
-                            if filters == [] or "filename" in filters:
+                            if filters == [] or "~filename" in filters:
                                 if text in file_.base_filename.lower():
                                     child_match = True
                                     break
-                            if filters == [] or "filepath" in filters:
+                            if filters == [] or "~filepath" in filters:
                                 if text in file_.filename.lower():
                                     child_match = True
                                     break

--- a/test/test_ui_filter.py
+++ b/test/test_ui_filter.py
@@ -87,16 +87,16 @@ class FilterxTest(PicardTestCase):
         self.assertTrue(hasattr(Filter, 'clear'))
         self.assertTrue(hasattr(Filter, 'set_focus'))
 
-    # @patch('picard.const.tags.ALL_TAGS', TEST_TAGS)
+    @patch('picard.ui.filter.ALL_TAGS', TEST_TAGS)
     def test_filter_button_text_logic(self):
         """Test the logic for updating filter button text from Filter._show_filter_dialog"""
         test_cases = [
             ([], None),
-            (["filename"], "Filename"),
+            (["~filename"], "File Name"),
             (["artist"], "Artist"),
             (["invalid_tag"], "invalid_tag"),
-            (["filename", "artist"], "2 filters"),
-            (["filename", "artist", "album", "title"], "4 filters"),
+            (["~filename", "artist"], "2 filters"),
+            (["~filename", "artist", "album", "title"], "4 filters"),
         ]
 
         for selected_filters, expected_text in test_cases:


### PR DESCRIPTION
There are three commits within this pull request:

1. https://github.com/jpmsousa03/picard/commit/e4cd231ccfbcb29df5bb0da86a7666d00b818d68 has been cherry picked to bring this branch up to date with the `master` branch in the `metabrainz` repository, and is required to make the second commit function as intended.

2. https://github.com/jpmsousa03/picard/commit/0a068df3cc38c461fa56d4cd70fa5cbfae47633f uses `filterable_tag_names()` to provide all filter items:
    - Remove special `filename` and `filepath` filter items.
    - Remove filter selection header sections.
    - Remove unnessary `str()` call.
    - Update `make_button_text()` method.
    - Perform file filtering based on `~filename` and `~filepath` filters.
    - Update tests.

3. https://github.com/jpmsousa03/picard/commit/bc151992c1ebff8abb3064c1a48aecd4b27568a0 adds standard tooltips to the filter items in the filter selector dialog.  This can be reverted or moved to a different PR if you like.